### PR TITLE
Explicit covariance in map img signature

### DIFF
--- a/hashcons.mli
+++ b/hashcons.mli
@@ -91,7 +91,7 @@ module Make(H : HashedType) : (S with type key = H.t)
 
 
 module Hmap : sig
-  type (+'a, 'b) t
+  type (+'a, +!'b) t
   type 'a key = 'a hash_consed
 
   val empty : ('a, 'b) t


### PR DESCRIPTION
I would like to be able to use `Hmap` and `Hset` mostly interchangeably with `Map` and `Set`, aka write functors 
`MakeHmap(T: TYPE) : Map.S with key = T.t hash_consed` and `MakeHset(T: TYPE) : Set.S with elt = T.t hash_consed`. 
 This works fine with `Set` (provided I supply the missing function), but fails with `Map` since `Map.S` specifies maps are injective and covariant in their image type. This is also true of `Hmap`s but isn't specified in the interface. This PR fixed that.

BTW if you think adding the missing functions needed to make `Hmap` and `Hset` closer to `Map` and `Set` let me know and I'll make another PR with them.