### PR TITLE
Extra Hset functions

### DIFF
--- a/hashcons.ml
+++ b/hashcons.ml
@@ -788,5 +788,25 @@ module Hset = struct
         false
 
   let disjoint s1 s2 = not (intersect s1 s2)
+
+  let find_any (type a) f (s : a t) =
+    let exception Found of a elt in
+    try
+      iter (fun elt -> if f elt then raise (Found elt)) s;
+      raise Not_found
+    with Found elt -> elt
+  let find_any_opt (type a) f (s : a t) =
+    let exception Found of a elt in
+    try
+      iter (fun elt -> if f elt then raise (Found elt)) s;
+      None
+    with Found elt -> Some elt
+
+  let bind f s = fold (fun elt s -> union (f elt) s) s empty
+
+  let is_singleton = function
+    | Leaf elt -> Some elt
+    | _ -> None
+
 end
 

--- a/hashcons.mli
+++ b/hashcons.mli
@@ -166,5 +166,14 @@ module Hset : sig
   (* [intersect u v] determines if sets [u] and [v] have a non-empty
      intersection. *)
   val intersect : 'a t -> 'a t -> bool
+
+  (* Faster finds when order doesn't matter *)
+  val find_any : ('a elt -> bool) -> 'a t -> 'a elt
+  val find_any_opt : ('a elt -> bool) -> 'a t -> 'a elt option
+
+  val is_singleton : 'a t -> 'a option
+  (* Check if the set is a singleton, if so return unique element *)
+
+  val bind : ('a -> 'b t) -> 'a t -> 'b t
 end
 

--- a/hashcons.mli
+++ b/hashcons.mli
@@ -120,21 +120,45 @@ module Hset : sig
   val diff : 'a t -> 'a t -> 'a t
   val equal : 'a t -> 'a t -> bool
   val compare : 'a t -> 'a t -> int
-  val elements : 'a t -> 'a elt list
   val choose : 'a t -> 'a elt
+  val choose_opt : 'a t -> 'a elt option
   val cardinal : 'a t -> int
-  val iter : ('a elt -> unit) -> 'a t -> unit
-  val fold : ('a elt -> 'b -> 'b) -> 'a t -> 'b -> 'b
   val for_all : ('a elt -> bool) -> 'a t -> bool
   val exists : ('a elt -> bool) -> 'a t -> bool
-  val filter : ('a elt -> bool) -> 'a t -> 'a t
   val partition : ('a elt -> bool) -> 'a t -> 'a t * 'a t
+  val disjoint : 'a t -> 'a t -> bool
+  val find : 'a elt -> 'a t -> 'a elt
+  val find_opt :  'a elt -> 'a t -> 'a elt option
+  val add_seq : 'a elt Seq.t -> 'a t -> 'a t
+  val of_seq : 'a elt Seq.t -> 'a t
+  val of_list : 'a elt list -> 'a t
+  val split : 'a elt -> 'a t -> 'a t * bool * 'a t
 
-  (*s Warning: [min_elt] and [max_elt] are linear w.r.t. the size of the
-      set. In other words, [min_elt t] is barely more efficient than [fold
-      min t (choose t)]. *)
+  (*s Warning: [iter], [fold], [map], [filter] and [map_filter] do NOT iterate
+      over element order. Similarly, [elements] and [to_seq] are not sorted. *)
+  val iter : ('a elt -> unit) -> 'a t -> unit
+  val fold : ('a elt -> 'b -> 'b) -> 'a t -> 'b -> 'b
+  val map : ('a elt -> 'b elt) -> 'a t -> 'b t
+  val filter : ('a elt -> bool) -> 'a t -> 'a t
+  val filter_map : ('a elt -> 'b elt option) -> 'a t -> 'b t
+  val elements : 'a t -> 'a elt list
+  val to_seq : 'a t -> 'a elt Seq.t
+
+  (*s Warning: [min_elt], [max_elt] and the [_opt] versions are linear w.r.t.
+      the size of the set. In other words, [min_elt t] is barely more efficient
+      than [fold min t (choose t)]. *)
   val min_elt : 'a t -> 'a elt
+  val min_elt_opt : 'a t -> 'a elt option
   val max_elt : 'a t -> 'a elt
+  val max_elt_opt : 'a t -> 'a elt option
+
+  (*s [find_first], [find_last] are linear time and can call [f] an arbitrary
+      number of times, and not necessarily on elements smaller/larger
+      than the witness. *)
+  val find_first : ('a elt -> bool) -> 'a t -> 'a elt
+  val find_first_opt : ('a elt -> bool) -> 'a t -> 'a elt option
+  val find_last : ('a elt -> bool) -> 'a t -> 'a elt
+  val find_last_opt : ('a elt -> bool) -> 'a t -> 'a elt option
 
   (*s Additional functions not appearing in the signature [Set.S] from ocaml
       standard library. *)

--- a/hashcons.mli
+++ b/hashcons.mli
@@ -171,9 +171,9 @@ module Hset : sig
   val find_any : ('a elt -> bool) -> 'a t -> 'a elt
   val find_any_opt : ('a elt -> bool) -> 'a t -> 'a elt option
 
-  val is_singleton : 'a t -> 'a option
+  val is_singleton : 'a t -> 'a elt option
   (* Check if the set is a singleton, if so return unique element *)
 
-  val bind : ('a -> 'b t) -> 'a t -> 'b t
+  val bind : ('a elt -> 'b t) -> 'a t -> 'b t
 end
 


### PR DESCRIPTION
Here are most of the missing function between `Hset` and `Set.S`. The notable exceptions are `to_seq_rev` and `to_seq_from` since the only reasonable way I could implement them is convert to list, then sort, then convert to seq...
I feel this bypasses the point of these function (provide efficient iterators). I did include `to_seq` but with the caveat that the result isn't sorted.

To be honest the order on hash consed terms is arbitrary anyway so I don't see anyone using these. Its also why I added a custom `find_any` an `find_any_opt` functions, as these seem more useful and can me made a bit faster.