### PR TITLE
dune: add missing deps

### DIFF
--- a/dune
+++ b/dune
@@ -11,6 +11,7 @@
  (name rule110)
  (modules rule110)
  (deps quicksort.term)
+ (enabled_if %{arch_sixtyfour})
  (libraries hashcons))
 
 (test

--- a/dune
+++ b/dune
@@ -10,10 +10,12 @@
 (test
  (name rule110)
  (modules rule110)
+ (deps quicksort.term)
  (libraries hashcons))
 
 (test
  (name test_qs)
  (modules test_qs)
  (flags ())
+ (deps quicksort.term)
  (libraries hashcons))


### PR DESCRIPTION
A lot of the CI tests are failing with:
```
Fatal error: exception Sys_error("quicksort.term: No such file or directory")
```

And indeed it reproduces locally too:
```
$ dune clean
$ dune runtest --cache=disabled
```

Add the missing dependency in `dune`.

