### PR TITLE
Remove duplicate `Weak.get` in `hashcons`

### DIFF
--- a/hashcons.ml
+++ b/hashcons.ml
@@ -108,11 +108,7 @@ let hashcons t d =
       hnode
     end else begin
       match Weak.get bucket i with
-        | Some v when v.node = d ->
-	    begin match Weak.get bucket i with
-              | Some v -> v
-              | None -> loop (i+1)
-            end
+        | Some v when v.node = d -> v
         | _ -> loop (i+1)
     end
   in
@@ -239,11 +235,7 @@ module Make(H : HashedType) : (S with type key = H.t) = struct
 	hnode
       end else begin
         match Weak.get bucket i with
-        | Some v when H.equal v.node d ->
-	    begin match Weak.get bucket i with
-              | Some v -> v
-              | None -> loop (i+1)
-            end
+        | Some v when H.equal v.node d -> v
         | _ -> loop (i+1)
       end
     in


### PR DESCRIPTION
In 4474c51e37255be8cc03e6f58e0d0979cca63191, the outer one was changed from `get_copy` to just `get`, kind of following https://github.com/ocaml/ocaml/pull/12131 upstream. However, instead of combining the two, duplication remained.