### PR TITLE
Compare `hkey` before `equal` on lookup

### DIFF
--- a/hashcons.ml
+++ b/hashcons.ml
@@ -108,7 +108,7 @@ let hashcons t d =
       hnode
     end else begin
       match Weak.get bucket i with
-        | Some v when v.node = d ->
+        | Some v when v.hkey = hkey && v.node = d ->
 	    begin match Weak.get bucket i with
               | Some v -> v
               | None -> loop (i+1)
@@ -239,7 +239,7 @@ module Make(H : HashedType) : (S with type key = H.t) = struct
 	hnode
       end else begin
         match Weak.get bucket i with
-        | Some v when H.equal v.node d ->
+        | Some v when v.hkey = hkey && H.equal v.node d ->
 	    begin match Weak.get bucket i with
               | Some v -> v
               | None -> loop (i+1)


### PR DESCRIPTION
In upstream, https://github.com/ocaml/ocaml/commit/db2092907f2eddcaf0b72f4bd0f429001364dbe5 changed many things at once. One of the improvements there is to add separate arrays for the hashes of elements in the buckets. On lookup, the hashes are compared before looking into the weak array itself and calling `equal`.

Here, hashes (or more precisely hkeys) are already stored (albeit in the weak array), so the separate hashes arrays probably wouldn't make sense. However, hkeys, which are already directly accessible, could be compared before the more expensive `equal` on the elements themselves.

Since this is just one part of the old upstream change ("fixed big performance bug"), I don't know if/how impactful this is for performance on its own and in this form.

This conflicts with #16 and #17, but I can fix things once either is merged.