### PR TITLE
open hash tables with linear probing

### DIFF
--- a/bench_bdd.ml
+++ b/bench_bdd.ml
@@ -1,0 +1,319 @@
+
+type t =
+  | Pvar of string
+  | Pnot of t
+  | Pand of t * t
+  | Por of  t * t
+  | Pimp of t * t
+  | Piff of t * t
+  | Ptrue
+  | Pfalse
+
+let pand p1 p2 = match p1, p2 with
+  | Ptrue, p2 -> p2
+  | p1, Ptrue -> p1
+  | _ -> Pand (p1, p2)
+
+let pands i j f =
+  let rec mk k = if k > j then Ptrue else pand (f k) (mk (k+1)) in
+  mk i
+
+let piff p1 p2 = match p1, p2 with
+  | Ptrue, p2 -> p2
+  | p1, Ptrue -> p1
+  | _ -> Piff (p1, p2)
+
+let piffs i j f =
+  let rec mk k = if k > j then Ptrue else piff (f k) (mk (k+1)) in
+  mk i
+
+let por p1 p2 = match p1, p2 with
+  | Pfalse, _p2 -> p1
+  | p1, Pfalse -> p1
+  | _ -> Por (p1, p2)
+
+let pors i j f =
+  let rec mk k = if k > j then Pfalse else por (f k) (mk (k+1)) in
+  mk i
+
+(* de bruijn *)
+
+let var i = Pvar ("p" ^ string_of_int i)
+
+let iff p1 p2 = Pand (Pimp (p1, p2), Pimp (p2, p1))
+
+(**
+de_bruijn_p(n) == LHS(2*n+1) -> RHS(2*n+1)
+de_bruijn_n(n) == LHS(2*n) -> (p0 v RHS(2*n) v ~p0)
+
+RHS(m) = &&_{i=1..m} p(i)
+LHS(m) = &&_{i=1..m} ((p(i)<->p(i+1)) -> c(n))
+where addition is computed modulo m.
+***)
+
+let lhs m =
+  pands 1 m (fun i -> Pnot (iff (var i) (var (if i=m then 1 else i+1))))
+
+let de_bruijn_p n = Pnot (lhs (2*n+1))
+let de_bruijn_n n = Pnot (lhs (2*n))
+
+(* pigeons
+
+ph_p(n) =def left(n) -> right(n)
+
+left(n) =def &&_{p=1..n+1} (vv_{j=1,..n} occ(i,j) )
+right(n) =def vv_{h=1..n, p1=1..{n+1}, p2={p1+1}..{n+1}} s(i1,i2,j)
+s(p1,p2,h) =def occ(p1,h) & occ(p2,h)
+
+*)
+
+let occ i j = Pvar ("occ_" ^ string_of_int i ^ "_" ^ string_of_int j)
+
+let left n = pands 1 (n+1) (fun i -> pors 1 n (fun j -> occ i j))
+let right n =
+  pors 1 n (fun h ->
+	      pors 1 (n+1) (fun p1 ->
+			      pors (p1+1) (n+1) (fun p2 -> Pand (occ p1 h,
+							    occ p2 h))))
+
+let pigeon_p n = Pimp (left n, right n)
+
+let equiv_p n =
+  let f = ref (var n) in
+  for i = 1 to n-1 do f := Piff (var (n-i), !f) done;
+  for i = 1 to n do f := Piff (var (n+1-i), !f) done;
+  !f
+
+let print fmt p =
+  let open Printf in
+  let rec pr fmt = function
+    | Pvar s -> fprintf fmt "%s" s
+    | Pnot f -> fprintf fmt "(~%a)" pr f
+    | Pand (f1, f2) -> fprintf fmt "(%a &@ %a)" pr f1 pr f2
+    | Por (f1, f2) -> fprintf fmt "(%a v@ %a)" pr f1 pr f2
+    | Pimp (f1, f2) -> fprintf fmt "(%a ->@ %a)" pr f1 pr f2
+    | Piff (f1, f2) -> fprintf fmt "(%a <->@ %a)" pr f1 pr f2
+    | Ptrue -> fprintf fmt "true"
+    | Pfalse -> fprintf fmt "false"
+  in
+  fprintf fmt "@[%a@]" pr p
+
+
+module Workload () = struct
+(* BDD *)
+
+open Hashcons
+
+type variable = int (* 1..max_var *)
+
+let max_var = ref 10
+let get_max_var () = !max_var
+let set_max_var n = if n <= 0 then invalid_arg "Bdd.set_max_var"; max_var := n
+
+type bdd = view hash_consed
+and view = Zero | One | Node of variable * bdd (*low*) * bdd (*high*)
+
+let view b = b.node
+
+module HC = Hashcons.Make(
+  struct
+    type t = view
+    let equal x y = match x, y with
+      | (Zero | One), (Zero | One) ->
+	  x == y
+      | Node (v1, l1, h1), Node (v2, l2, h2) ->
+	  v1 == v2 && l1 == l2 && h1 == h2
+      | _ ->
+	  false
+    let hash = function
+      | Zero -> 0
+      | One -> 1
+      | Node (v, l, h) -> abs (19 * (19 * l.tag + h.tag) + v)
+  end)
+
+let htable = HC.create 251
+
+let zero = HC.hashcons htable Zero
+let one = HC.hashcons htable One
+
+let var b = match b.node with
+  | Zero | One -> !max_var + 1
+  | Node (v, _, _) -> v
+
+let low b = match b.node with
+  | Zero | One -> invalid_arg "Bdd.low"
+  | Node (_, l, _) -> l
+
+let high b = match b.node with
+  | Zero | One -> invalid_arg "Bdd.low"
+  | Node (_, _, h) -> h
+
+let mk v ~low ~high =
+  if low == high then low else HC.hashcons htable (Node (v, low, high))
+
+let mk_var v = mk v ~low:zero ~high:one
+
+module Bdd = struct
+  type t = bdd
+  let equal = (==)
+  let hash b = b.tag
+  let compare b1 b2 = Stdlib.compare b1.tag b2.tag
+end
+module H1 = Hashtbl.Make(Bdd)
+
+let mk_not x =
+  let cache = H1.create 251 in
+  let rec mk_not_rec x =
+    try
+      H1.find cache x
+    with Not_found ->
+      let res = match x.node with
+	| Zero -> one
+	| One -> zero
+	| Node (v, l, h) -> mk v ~low:(mk_not_rec l) ~high:(mk_not_rec h)
+      in
+      H1.add cache x res;
+      res
+  in
+  mk_not_rec x
+
+let bool_of = function Zero -> false | One -> true | _ -> invalid_arg "bool_of"
+let of_bool b = if b then one else zero
+
+module H2 = Hashtbl.Make(
+  struct
+    type t = bdd * bdd
+    let equal (u1,v1) (u2,v2) = u1==u2 && v1==v2
+    let hash (u,v) =
+      (*abs (19 * u.tag + v.tag)*)
+      let s = u.tag + v.tag in abs (s * (s+1) / 2 + u.tag)
+  end)
+
+let apply op =
+  let op_z_z = of_bool (op false false) in
+  let op_z_o = of_bool (op false true) in
+  let op_o_z = of_bool (op true false) in
+  let op_o_o = of_bool (op true true) in
+  fun b1 b2 ->
+    let cache = H2.create 251 in
+    let rec app ((u1,u2) as u12) =
+      try
+	H2.find cache u12
+      with Not_found ->
+	let res = match u1.node, u2.node with
+	  | Zero, Zero -> op_z_z
+	  | Zero, One  -> op_z_o
+	  | One,  Zero -> op_o_z
+	  | One,  One  -> op_o_o
+	  | _ ->
+	      let v1 = var u1 in
+	      let v2 = var u2 in
+	      if v1 == v2 then
+		mk v1 ~low:(app (low u1, low u2)) ~high:(app (high u1, high u2))
+	      else if v1 < v2 then
+		mk v1 ~low:(app (low u1, u2)) ~high:(app (high u1, u2))
+	      else (* v1 > v2 *)
+		mk v2 ~low:(app (u1, low u2)) ~high:(app (u1, high u2))
+	in
+	H2.add cache u12 res;
+	res
+    in
+    app (b1, b2)
+
+
+type boolean_op = bool -> bool -> bool
+let op_and = (&&)
+let op_or = (||)
+let op_imp b1 b2 = (not b1) || b2
+
+let mk_and = apply op_and
+let mk_or = apply op_or
+let mk_imp = apply op_imp
+
+(* satisfiability *)
+
+let is_sat b = b.node != Zero
+
+let tautology b = b.node == One
+
+(* formula -> bdd *)
+
+type formula =
+  | Ffalse
+  | Ftrue
+  | Fvar of variable
+  | Fand of formula * formula
+  | For  of formula * formula
+  | Fimp of formula * formula
+  | Fnot of formula
+
+let rec build = function
+  | Ffalse -> zero
+  | Ftrue -> one
+  | Fvar v -> mk_var v
+  | Fand (f1, f2) -> mk_and (build f1) (build f2)
+  | For (f1, f2) -> mk_or (build f1) (build f2)
+  | Fimp (f1, f2) -> mk_imp (build f1) (build f2)
+  | Fnot f -> mk_not (build f)
+
+
+let bdd_of_formula f =
+  let nbvar = ref 0 in
+  let vars = Hashtbl.create 17 in
+  let rec trans = function
+    | Pvar s ->
+	Fvar (try Hashtbl.find vars s
+	      with Not_found -> incr nbvar; Hashtbl.add vars s !nbvar; !nbvar)
+    | Pnot f -> Fnot (trans f)
+    | Pand (f1, f2) -> Fand (trans f1, trans f2)
+    | Por (f1, f2) -> For (trans f1, trans f2)
+    | Pimp (f1, f2) -> Fimp (trans f1, trans f2)
+    | Piff (f1, f2) -> let f1 = trans f1 and f2 = trans f2 in
+                       Fand (Fimp (f1, f2), Fimp (f2, f1))
+    | Ptrue -> Ftrue
+    | Pfalse -> Ffalse
+  in
+  let f = trans f in
+  set_max_var !nbvar;
+  Printf.printf "nb var = %d\n%!" !nbvar;
+  build f
+
+end
+
+(* bench *)
+
+let domains = ref 1
+type bench = De_bruijn | Pigeon
+let bench = ref De_bruijn
+let n = ref 10
+let verbose = ref false
+
+let () =
+  Arg.parse
+      ["-de-bruijn", Arg.Unit (fun () -> bench := De_bruijn), "";
+       "-pigeon", Arg.Unit (fun () -> bench := Pigeon), "";
+       "-v", Arg.Set verbose, "";
+       "-domains", Arg.Set_int domains, "";
+      ]
+      (fun x -> n := int_of_string x)
+      "";
+  let f = match !bench with
+    | De_bruijn -> de_bruijn_p !n
+    | Pigeon    -> pigeon_p !n in
+  let work () =
+    let module W = Workload () in
+    let b = W.bdd_of_formula f in
+    assert (W.tautology b);
+    if !verbose then begin
+      let dom_id = (Domain.self () :> int) in
+      let l,n,s,b1,b2,b3 = W.(HC.stats htable) in
+      Printf.printf "[%d] table length: %d / nb. entries: %d / sum of bucket length: %d@."
+        dom_id l n s;
+      Printf.printf "[%d] smallest bucket: %d / median bucket: %d / biggest bucket: %d@."
+        dom_id b1 b2 b3
+    end
+  in
+  let workers = List.init (!domains - 1) (fun _ -> Domain.spawn work) in
+  work ();
+  List.iter Domain.join workers
+

--- a/dune
+++ b/dune
@@ -13,6 +13,11 @@
  (libraries hashcons))
 
 (test
+ (name bench_bdd)
+ (modules bench_bdd)
+ (libraries hashcons))
+
+(test
  (name test_qs)
  (modules test_qs)
  (flags ())

--- a/hashcons.ml
+++ b/hashcons.ml
@@ -87,7 +87,6 @@ type 'a t = {
   mutable occupation : int;
   mutable mask : int; (* Array.length hashes - 1
     (note: the length must be a power of two) *)
-  travel : int ref;
 }
 
 let create sz =
@@ -103,7 +102,6 @@ let create sz =
     keys = Weak.create sz;
     occupation = 0;
     mask = sz - 1;
-    travel = ref 0;
   }
 
 let clear t =
@@ -132,10 +130,9 @@ let rec locate_gen ~equal t k h =
   if verbose then incr locate_calls;
   let i = (h : H.t :> int) land t.mask in
   locate_gen_loop
-    ~equal ~mask:t.mask ~travel:t.travel
+    ~equal ~mask:t.mask
     t.keys k t.hashes h ~first_dead:(-1) i
-and locate_gen_loop ~equal ~mask ~travel keys k hashes h ~first_dead i =
-  incr travel;
+and locate_gen_loop ~equal ~mask keys k hashes h ~first_dead i =
   if verbose then incr locate_travel;
   let h' = Array.unsafe_get hashes i in
   let i' = (i + 1) land mask in
@@ -144,20 +141,20 @@ and locate_gen_loop ~equal ~mask ~travel keys k hashes h ~first_dead i =
       let i = if first_dead < 0 then i else first_dead in
       Error (i, first_dead < 0)
     end
-    else locate_gen_loop ~equal ~mask ~travel keys k hashes h ~first_dead i'
+    else locate_gen_loop ~equal ~mask keys k hashes h ~first_dead i'
   else
     match Weak.get keys i with
     | Some hc when equal k hc.node -> Ok hc
     | Some hc ->
       if equal k hc.node then Ok hc
-      else locate_gen_loop ~equal ~mask ~travel keys k hashes h ~first_dead i'
+      else locate_gen_loop ~equal ~mask keys k hashes h ~first_dead i'
     | None ->
       (* When a value has been erased by the GC (case [None]), we must
          keep looking further for another value with the same hash. It
          would be incorrect to treat it as a [void] hash, for the same
          reason that François distinguishes [tomb] from [void]. *)
       let first_dead = if first_dead < 0 then i else first_dead in
-      locate_gen_loop ~equal ~mask ~travel keys k hashes h ~first_dead i'
+      locate_gen_loop ~equal ~mask keys k hashes h ~first_dead i'
 
 let next_sz n = min (2*n) (Sys.max_array_length / 2)
 
@@ -265,26 +262,6 @@ let hashcons_gen ~hash ~equal t k =
     if real_occupation < capacity t / 2
     then compress ~equal t
     else resize_gen ~equal t;
-    t.travel := 0;
-  end
-  else if !(t.travel) > 42 * capacity t then begin
-    (* In workloads where hits dominate misses, the table grows very
-       slowly, so the crowded criterion rarely applies. It remains
-       useful to compress it from time to time, to get a chance to
-       remove collected values and thus speedup future lookups.
-
-       To compress regularly, we measure the 'travel' caused by
-       lookups, the total number of positions they have visited since
-       the last resizing or compression. When they have visited many
-       times the total size of the structure, we have amortized the
-       cost of a compression.
-
-       On [test_qs.ml] from the [ocaml-hashcons] repository (99.8%
-       hit rate), this extra source of compression reduces average
-       lookup travel from 5.4 to 1.3, and runtime is reduced from 1.7s
-       to 1.3s. *)
-    compress ~equal t;
-    t.travel := 0;
   end;
   let hkey = hash k in
   let h = H.of_int hkey in

--- a/hashcons.ml
+++ b/hashcons.ml
@@ -126,6 +126,13 @@ let () = if verbose then at_exit (fun () ->
     (float !locate_travel /. float !locate_calls)
 )
 
+(* The result of [locate] functions: either we found an equal
+   element at a certain position, or we stopped on a void or dead slot. *)
+type 'a finding =
+| Found of 'a
+| Void of int
+| Dead of int
+
 let rec locate_gen ~equal t k h =
   if verbose then incr locate_calls;
   let i = (h : H.t :> int) land t.mask in
@@ -138,15 +145,14 @@ and locate_gen_loop ~equal ~mask keys k hashes h ~first_dead i =
   let i' = (i + 1) land mask in
   if h' <> h then
     if h' = H.void then begin
-      let i = if first_dead < 0 then i else first_dead in
-      Error (i, first_dead < 0)
+      if first_dead < 0 then Void i else Dead first_dead
     end
     else locate_gen_loop ~equal ~mask keys k hashes h ~first_dead i'
   else
     match Weak.get keys i with
-    | Some hc when equal k hc.node -> Ok hc
+    | Some hc when equal k hc.node -> Found hc
     | Some hc ->
-      if equal k hc.node then Ok hc
+      if equal k hc.node then Found hc
       else locate_gen_loop ~equal ~mask keys k hashes h ~first_dead i'
     | None ->
       (* When a value has been erased by the GC (case [None]), we must
@@ -181,11 +187,14 @@ let resize_gen ~equal t =
     | Some hc ->
       let h = Array.unsafe_get old_hashes i in
       match locate_gen ~equal t hc.node h with
-      | Ok _ ->
+      | Found _ ->
         failwith "resize: key already in the table?";
-      | Error (i, void_or_dead) ->
-        if void_or_dead then
-          t.occupation <- t.occupation + 1;
+      | Void i ->
+        t.occupation <- t.occupation + 1;
+        Weak.set new_keys i (Some hc);
+        new_hashes.(i) <- h;
+      | Dead i ->
+        (* reusing a dead slot: no occupation increase *)
         Weak.set new_keys i (Some hc);
         new_hashes.(i) <- h;
   done;
@@ -212,9 +221,11 @@ let compress ~equal t =
         t.hashes.(i) <- H.void;
       | Some hc ->
         match locate_gen ~equal t hc.node h with
-        | Ok _ -> ()
-        | Error (j, void_or_dead) ->
-          if verbose then assert void_or_dead;
+        | Found _ -> ()
+        | Dead _ ->
+          (* we cannot encounter dead slots during compression! *)
+          assert false
+        | Void j ->
           Weak.set t.keys j (Some hc);
           Weak.set t.keys i None;
           t.hashes.(j) <- t.hashes.(i);
@@ -266,16 +277,18 @@ let hashcons_gen ~hash ~equal t k =
   let hkey = hash k in
   let h = H.of_int hkey in
   match locate_gen ~equal t k h with
-  | Ok hc ->
+  | Found hc ->
     if verbose then incr hits;
     hc
-  | Error (i, void_or_dead) ->
+  | (Void i | Dead i) as finding ->
     if verbose then incr misses;
     let hc = { hkey; tag = gentag (); node = k } in
     Weak.set t.keys i (Some hc);
     Array.unsafe_set t.hashes i h;
-    if void_or_dead then
-      t.occupation <- t.occupation + 1;
+    (match finding with
+     | Void _ ->
+       t.occupation <- t.occupation + 1
+     | _ -> ());
     hc
 
 let stats t =

--- a/hashcons.ml
+++ b/hashcons.ml
@@ -25,102 +25,277 @@ let gentag =
   let r = ref 0 in
   fun () -> incr r; !r
 
+(* Enable this boolean to get performance information
+   during program execution and on program exit. *)
+let verbose = false
+
+(* H.t is a representation of hashes as stored within the [hashes]
+   array below. We reserve 0 to denote a distinguished 'void' value
+   which corresponds to the absence of a key in this position.
+
+   Note: François Pottier's implementation
+   ( https://github.com/fpottier/hachis/ ) also contains
+   a distinguished 'tomb' value for slots whose key has been removed
+   (Hashtbl.remove). For hash-consing we do not need to handle
+   explicit removal; we could use tombstones for keys that get erased
+   by the GC, but we just leave the hashes around until the next
+   resizing or compression.
+*)
+module H : sig
+  type t = private int
+  val void : t
+  val of_int : int -> t
+end = struct
+  type t = int
+  let void = 0
+  let of_int x =
+    if x = void then void + 1 else x
+end
+
 type 'a t = {
-  mutable table : 'a hash_consed Weak.t array;
-  mutable totsize : int;             (* sum of the bucket sizes *)
-  mutable limit : int;               (* max ratio totsize/table length *)
+  mutable hashes : H.t array;
+  mutable keys : 'a hash_consed Weak.t;
+  mutable occupation : int;
+  mutable mask : int; (* Array.length hashes - 1
+    (note: the length must be a power of two) *)
+  travel : int ref;
 }
 
 let create sz =
-  let sz = if sz < 7 then 7 else sz in
-  let sz = if sz > Sys.max_array_length then Sys.max_array_length else sz in
-  let emptybucket = Weak.create 0 in
-  { table = Array.make sz emptybucket;
-    totsize = 0;
-    limit = 3; }
+  (* We need to guarantee that there is always at least one [void]
+     slot for search to terminate, so [sz] must be at least 1.
+     We also guarantee that sizes are always a power of 2,
+     to compute the modulo efficiently. *)
+  let sz' = ref 1 in
+  while !sz' < sz do sz' := 2 * !sz' done;
+  let sz = !sz' in
+  {
+    hashes = Array.make sz H.void;
+    keys = Weak.create sz;
+    occupation = 0;
+    mask = sz - 1;
+    travel = ref 0;
+  }
 
 let clear t =
-  let emptybucket = Weak.create 0 in
-  for i = 0 to Array.length t.table - 1 do t.table.(i) <- emptybucket done;
-  t.totsize <- 0;
-  t.limit <- 3
+  Weak.fill t.keys 0 (Weak.length t.keys) None;
+  Array.fill t.hashes 0 (Array.length t.hashes) H.void;
+  t.occupation <- 0
 
 let iter f t =
-  let rec iter_bucket i b =
-    if i >= Weak.length b then () else
-      match Weak.get b i with
-	| Some v -> f v; iter_bucket (i+1) b
-	| None -> iter_bucket (i+1) b
+  let len = Array.length t.hashes in
+  for i = 0 to len - 1 do
+    match Weak.get t.keys i with
+    | None -> ()
+    | Some hc -> f hc
+  done
+
+let locate_calls = ref 0
+let locate_travel = ref 0
+
+let () = if verbose then at_exit (fun () ->
+  Printf.eprintf "Hashcons locate: calls %d, average travel %g/call\n%!"
+    !locate_calls
+    (float !locate_travel /. float !locate_calls)
+)
+
+let rec locate_gen ~equal t k h =
+  if verbose then incr locate_calls;
+  let i = h land t.mask in
+  locate_gen_loop
+    ~equal ~mask:t.mask ~travel:t.travel
+    t.keys k t.hashes (H.of_int h) i
+and locate_gen_loop ~equal ~mask ~travel keys k hashes h i =
+  incr travel;
+  if verbose then incr locate_travel;
+  let h' = Array.unsafe_get hashes i in
+  let i' = (i + 1) land mask in
+  if h' <> h then
+    if h' = H.void then Error i
+    else locate_gen_loop ~equal ~mask ~travel keys k hashes h i'
+  else
+    match Weak.get keys i with
+    | Some hc when equal k hc.node -> Ok hc
+    | _ ->
+      (* When a value has been erased by the GC (case [None]), we must
+         keep looking further for another value with the same hash. It
+         would be incorrect to treat it as a [void] hash, for the same
+         reason that François distinguishes [tomb] from [void]. *)
+      locate_gen_loop ~equal ~mask ~travel keys k hashes h i'
+
+let next_sz n = min (2*n) (Sys.max_array_length / 2)
+
+let resize_count = ref 0
+
+let resize_gen ~equal t =
+  if verbose then incr resize_count;
+  let old_occupation = t.occupation in
+  let old_capacity = Array.length t.hashes in
+  let old_hashes, old_keys = t.hashes, t.keys in
+  let new_capacity = next_sz old_capacity in
+  let new_mask = new_capacity - 1 in
+  let new_hashes, new_keys =
+    Array.make new_capacity H.void,
+    Weak.create new_capacity
   in
-  Array.iter (iter_bucket 0) t.table
-
-let count t =
-  let rec count_bucket i b accu =
-    if i >= Weak.length b then accu else
-      count_bucket (i+1) b (accu + (if Weak.check b i then 1 else 0))
-  in
-  Array.fold_right (count_bucket 0) t.table 0
-
-let next_sz n = min (3*n/2 + 3) (Sys.max_array_length - 1)
-
-let rec resize t =
-  let oldlen = Array.length t.table in
-  let newlen = next_sz oldlen in
-  if newlen > oldlen then begin
-    let newt = create newlen in
-    newt.limit <- t.limit + 100;          (* prevent resizing of newt *)
-    iter (fun d -> add newt d) t;
-    t.table <- newt.table;
-    t.totsize <- newt.totsize
-  end
-
-and add t d =
-  let index = d.hkey mod (Array.length t.table) in
-  let bucket = t.table.(index) in
-  let sz = Weak.length bucket in
-  let i = ref 0 in
-  while !i < sz && Weak.check bucket !i do incr i done;
-  if !i < sz then
-    Weak.set bucket !i (Some d)
-  else begin
-    let newsz = min (3 * sz / 2 + 3) (Sys.max_array_length - 1) in
-    if newsz <= sz then
-      failwith "Hashcons.Make: hash bucket cannot grow more";
-    let newbucket = Weak.create newsz in
-    Weak.blit bucket 0 newbucket 0 sz;
-    Weak.set newbucket sz (Some d);
-    t.table.(index) <- newbucket;
-    t.totsize <- t.totsize + (newsz - sz);
-    if t.totsize > t.limit * Array.length t.table then resize t;
-  end
-
-let hashcons t d =
-  let hkey = Hashtbl.hash d land max_int in
-  let index = hkey mod (Array.length t.table) in
-  let bucket = t.table.(index) in
-  let sz = Weak.length bucket in
-  let found = ref None in
-  let i = ref 0 in
-  while !i < sz && Option.is_none !found do
-    match Weak.get bucket !i with
-    | Some v as opt when v.hkey = hkey && v.node = d ->
-      found := opt
-    | _ -> incr i
+  t.hashes <- new_hashes;
+  t.keys <- new_keys;
+  t.mask <- new_mask;
+  t.occupation <- 0;
+  for i = 0 to old_capacity - 1 do
+    match Weak.get old_keys i with
+    | None -> ()
+    | Some hc ->
+      let h = Array.unsafe_get old_hashes i in
+      match locate_gen ~equal t hc.node hc.hkey with
+      | Ok _ ->
+        failwith "resize: key already in the table?";
+      | Error i ->
+        t.occupation <- t.occupation + 1;
+        Weak.set new_keys i (Some hc);
+        new_hashes.(i) <- h;
   done;
-  match !found with
-  | Some v -> v
-  | None ->
-    let hnode = { hkey = hkey; tag = gentag (); node = d } in
-    add t hnode;
-    hnode
+  let new_occupation = t.occupation in
+  if verbose then
+    Printf.eprintf "[%.2d] Resize: size %d=>%d, occupation %d=>%d\n%!"
+      !resize_count
+      old_capacity new_capacity
+      old_occupation new_occupation;
+  ()
+
+let compress ~equal t =
+  if verbose then incr resize_count;
+  let old_occupation = t.occupation in
+  let first_void = Array.find_index ((=) H.void) t.hashes |> Option.get in
+  let len = Array.length t.hashes in
+  for i = 0 to len - 1 do
+    let i = (first_void + i) mod len in
+    if t.hashes.(i) <> H.void then
+      match Weak.get t.keys i with
+      | None ->
+        t.occupation <- t.occupation - 1;
+        t.hashes.(i) <- H.void;
+      | Some hc ->
+        match locate_gen ~equal t hc.node hc.hkey with
+        | Ok _ -> ()
+        | Error j ->
+          Weak.set t.keys j (Some hc);
+          Weak.set t.keys i None;
+          t.hashes.(j) <- t.hashes.(i);
+          t.hashes.(i) <- H.void;
+  done;
+  let new_occupation = t.occupation in
+  if verbose then
+    Printf.eprintf "[%.2d] Compression: occupation %d=>%d\n%!"
+      !resize_count old_occupation new_occupation;
+  ()
+
+let[@inline] capacity t =
+  t.mask + 1
+
+let crowded t =
+  (* resize at 82% occupation (105/128);
+     from François Pottier's [hachis] library. *)
+  128 * t.occupation > 105 * capacity t
+
+let calls = ref 0
+let hits = ref 0
+let misses = ref 0
+let () = if verbose then at_exit (fun () ->
+  let ratio n = 100. *. float n /. float !calls in
+  Printf.eprintf "Hachcons calls %d: hits %d (%g%%), misses %d (%g%%).\n%!"
+    !calls
+    !hits (ratio !hits)
+    !misses (ratio !misses)
+)
+
+let hashcons_gen ~hash ~equal t k =
+  if verbose then incr calls;
+  if crowded t then begin
+    (* Our estimation of occupation does not take into account weak
+       keys that have been removed by the GC. When the occupation
+       becomes high and we consider resizing, we first loook at
+       whether the real occupation is low enough that no resizing is
+       necessary -- in this case we just compress the data in-place,
+       without moving to larger backing arrays. *)
+    let real_occupation =
+      let count = ref 0 in
+      iter (fun _ -> incr count) t;
+      !count
+    in
+    if real_occupation < capacity t / 2
+    then compress ~equal t
+    else resize_gen ~equal t;
+    t.travel := 0;
+  end
+  else if !(t.travel) > 42 * capacity t then begin
+    (* In workloads where hits dominate misses, the table grows very
+       slowly, so the crowded criterion rarely applies. It remains
+       useful to compress it from time to time, to get a chance to
+       remove collected values and thus speedup future lookups.
+
+       To compress regularly, we measure the 'travel' caused by
+       lookups, the total number of positions they have visited since
+       the last resizing or compression. When they have visited many
+       times the total size of the structure, we have amortized the
+       cost of a compression.
+
+       On [test_qs.ml] from the [ocaml-hashcons] repository (99.8%
+       hit rate), this extra source of compression reduces average
+       lookup travel from 5.4 to 1.3, and runtime is reduced from 1.7s
+       to 1.3s. *)
+    compress ~equal t;
+    t.travel := 0;
+  end;
+  let h = hash k land max_int in
+  match locate_gen ~equal t k h with
+  | Ok hc ->
+    if verbose then incr hits;
+    hc
+  | Error i ->
+    if verbose then incr misses;
+    let hc = { hkey = h; tag = gentag (); node = k } in
+    Weak.set t.keys i (Some hc);
+    Array.unsafe_set t.hashes i (H.of_int h);
+    t.occupation <- t.occupation + 1;
+    hc
 
 let stats t =
-  let len = Array.length t.table in
-  let lens = Array.map Weak.length t.table in
-  Array.sort compare lens;
-  let totlen = Array.fold_left ( + ) 0 lens in
-  (len, count t, totlen, lens.(0), lens.(len/2), lens.(len-1))
+  (* len: number of non-void hashes. *)
+  let len = t.occupation in
+  (* count: number of live keys *)
+  let count =
+    let i = ref 0 in iter (fun _ -> incr i) t; !i in
+  (* totlen: total capacity *)
+  let totlen = Array.length t.hashes in
+  (* For the statistical information that used to correspond to bucket
+     sizes, we compute the size of filled intervals in-between void
+     keys. *)
+  let interval_lens =
+    let voids = ref [] in
+    Array.iteri (fun i h -> if h == H.void then voids := i :: !voids) t.hashes;
+    let voids = Array.of_list (List.rev !voids) in
+    List.init (Array.length voids - 1) (fun i ->
+      if i < Array.length voids - 1 then
+        voids.(i + 1) - voids.(i) - 1
+      else
+        Array.length t.hashes - voids.(i) - 1
+        + voids.(0)
+    )
+    |> List.filter ((<>) 0) (* filter out empty gaps *)
+    |> Array.of_list
+  in
+  let nb_intervals = Array.length interval_lens in
+  Array.sort compare interval_lens;
+  (len, count, totlen,
+   interval_lens.(0),
+   interval_lens.(nb_intervals / 2),
+   interval_lens.(nb_intervals - 1))
 
+(* Specialized definitions with Stdlib's hashing and comparison. *)
+
+let hashcons t k =
+  hashcons_gen ~hash:Hashtbl.hash ~equal:(=) t k
 
 (* Functorial interface *)
 
@@ -142,112 +317,15 @@ module type S =
     val stats : t -> int * int * int * int * int * int
   end
 
-module Make(H : HashedType) : (S with type key = H.t) = struct
+module Make(K : HashedType) : (S with type key = K.t) = struct
+  type key = K.t
+  type nonrec t = K.t t
 
-  type key = H.t
-
-  type data = H.t hash_consed
-
-  type t = {
-    mutable table : data Weak.t array;
-    mutable totsize : int;             (* sum of the bucket sizes *)
-    mutable limit : int;               (* max ratio totsize/table length *)
-  }
-
-  let emptybucket = Weak.create 0
-
-  let create sz =
-    let sz = if sz < 7 then 7 else sz in
-    let sz = if sz > Sys.max_array_length then Sys.max_array_length else sz in
-    {
-      table = Array.make sz emptybucket;
-      totsize = 0;
-      limit = 3;
-    }
-
-  let clear t =
-    for i = 0 to Array.length t.table - 1 do
-      t.table.(i) <- emptybucket
-    done;
-    t.totsize <- 0;
-    t.limit <- 3
-
-  let iter f t =
-    let rec iter_bucket i b =
-      if i >= Weak.length b then () else
-      match Weak.get b i with
-      | Some v -> f v; iter_bucket (i+1) b
-      | None -> iter_bucket (i+1) b
-    in
-    Array.iter (iter_bucket 0) t.table
-
-  let count t =
-    let rec count_bucket i b accu =
-      if i >= Weak.length b then accu else
-      count_bucket (i+1) b (accu + (if Weak.check b i then 1 else 0))
-    in
-    Array.fold_right (count_bucket 0) t.table 0
-
-  let next_sz n = min (3*n/2 + 3) (Sys.max_array_length - 1)
-
-  let rec resize t =
-    let oldlen = Array.length t.table in
-    let newlen = next_sz oldlen in
-    if newlen > oldlen then begin
-      let newt = create newlen in
-      newt.limit <- t.limit + 100;          (* prevent resizing of newt *)
-      iter (fun d -> add newt d) t;
-      t.table <- newt.table;
-      t.totsize <- newt.totsize
-    end
-
-  and add t d =
-    let index = d.hkey mod (Array.length t.table) in
-    let bucket = t.table.(index) in
-    let sz = Weak.length bucket in
-    let i = ref 0 in
-    while !i < sz && Weak.check bucket !i do incr i done;
-    if !i < sz then
-      Weak.set bucket !i (Some d)
-    else begin
-      let newsz = min (3 * sz / 2 + 3) (Sys.max_array_length - 1) in
-      if newsz <= sz then
-        failwith "Hashcons.Make: hash bucket cannot grow more";
-      let newbucket = Weak.create newsz in
-      Weak.blit bucket 0 newbucket 0 sz;
-      Weak.set newbucket sz (Some d);
-      t.table.(index) <- newbucket;
-      t.totsize <- t.totsize + (newsz - sz);
-      if t.totsize > t.limit * Array.length t.table then resize t;
-    end
-
-  let hashcons t d =
-    let hkey = H.hash d land max_int in
-    let index = hkey mod (Array.length t.table) in
-    let bucket = t.table.(index) in
-    let sz = Weak.length bucket in
-    let found = ref None in
-    let i = ref 0 in
-    while !i < sz && Option.is_none !found do
-      match Weak.get bucket !i with
-      | Some v as opt when v.hkey = hkey && H.equal v.node d ->
-        found := opt
-      | _ -> incr i
-    done;
-    match !found with
-    | Some v -> v
-    | None ->
-      let hnode = { hkey = hkey; tag = gentag (); node = d } in
-      add t hnode;
-      hnode
-
-  let stats t =
-    let len = Array.length t.table in
-    let lens = Array.map Weak.length t.table in
-    Array.sort compare lens;
-    let totlen = Array.fold_left ( + ) 0 lens in
-    (len, count t, totlen, lens.(0), lens.(len/2), lens.(len-1))
-
+  let create = create
+  let clear = clear
+  let hashcons t k = hashcons_gen ~hash:K.hash ~equal:K.equal t k
+  let iter = iter
+  let stats = stats
 end
 
 

--- a/hashcons.ml
+++ b/hashcons.ml
@@ -49,6 +49,35 @@ end = struct
   type t = int
   let void = 0
   let of_int x =
+    (* Open-adressing hashtables need hash values that are "random
+       enough" so that void elements are spread almost-randomly, to
+       avoid long sequences of consecutive non-void elements. In this
+       respect they are more sensitive than array-of-bucket designs.
+
+       For example, if you consider the set of consecutive integers
+       range [0,999], then (i -> i mod 500) is a reasonable hash
+       function for an array-of-bucket design, you will get two
+       conflict per hash and thus exactly two elements per bucket. But
+       with an open-adressing hashable, it would give terrible
+       results: if elements get added in order, when element '500'
+       gets added all slots [0,499] will already be taken, so it will
+       travel 500 steps until position 500, and similarly all other
+       integers in [500,999] will be 500 position away from their
+       hash.
+
+       Getting such a consecutive range of hashes with overlaps is
+       unfortunately relatively with common hand-written,
+       user-provided hash functions, for example one that sends the
+       pair (x, y) to the hash (alpha * x + y). These functions would
+       provide good performance with an array-of-bucket
+       implementation, but can result in catastrophic travel
+       statistics for open-addressing schemes.
+
+       To avoid this issue, we multiply the hashes by a large prime
+       number (found in hash.c, the C implementation of hashing in the
+       OCaml runtime), which will 'spread' consecutive integers to
+       a much larger range with gaps between them. *)
+    let x = x * 0xcc9e2d51 in
     if x = void then void + 1 else x
 end
 
@@ -101,10 +130,10 @@ let () = if verbose then at_exit (fun () ->
 
 let rec locate_gen ~equal t k h =
   if verbose then incr locate_calls;
-  let i = h land t.mask in
+  let i = (h : H.t :> int) land t.mask in
   locate_gen_loop
     ~equal ~mask:t.mask ~travel:t.travel
-    t.keys k t.hashes (H.of_int h) i
+    t.keys k t.hashes h i
 and locate_gen_loop ~equal ~mask ~travel keys k hashes h i =
   incr travel;
   if verbose then incr locate_travel;
@@ -147,7 +176,7 @@ let resize_gen ~equal t =
     | None -> ()
     | Some hc ->
       let h = Array.unsafe_get old_hashes i in
-      match locate_gen ~equal t hc.node hc.hkey with
+      match locate_gen ~equal t hc.node h with
       | Ok _ ->
         failwith "resize: key already in the table?";
       | Error i ->
@@ -170,13 +199,14 @@ let compress ~equal t =
   let len = Array.length t.hashes in
   for i = 0 to len - 1 do
     let i = (first_void + i) mod len in
-    if t.hashes.(i) <> H.void then
+    let h = t.hashes.(i) in
+    if h <> H.void then
       match Weak.get t.keys i with
       | None ->
         t.occupation <- t.occupation - 1;
         t.hashes.(i) <- H.void;
       | Some hc ->
-        match locate_gen ~equal t hc.node hc.hkey with
+        match locate_gen ~equal t hc.node h with
         | Ok _ -> ()
         | Error j ->
           Weak.set t.keys j (Some hc);
@@ -247,16 +277,17 @@ let hashcons_gen ~hash ~equal t k =
     compress ~equal t;
     t.travel := 0;
   end;
-  let h = hash k land max_int in
+  let hkey = hash k in
+  let h = H.of_int hkey in
   match locate_gen ~equal t k h with
   | Ok hc ->
     if verbose then incr hits;
     hc
   | Error i ->
     if verbose then incr misses;
-    let hc = { hkey = h; tag = gentag (); node = k } in
+    let hc = { hkey; tag = gentag (); node = k } in
     Weak.set t.keys i (Some hc);
-    Array.unsafe_set t.hashes i (H.of_int h);
+    Array.unsafe_set t.hashes i h;
     t.occupation <- t.occupation + 1;
     hc
 

--- a/hashcons.ml
+++ b/hashcons.ml
@@ -133,24 +133,31 @@ let rec locate_gen ~equal t k h =
   let i = (h : H.t :> int) land t.mask in
   locate_gen_loop
     ~equal ~mask:t.mask ~travel:t.travel
-    t.keys k t.hashes h i
-and locate_gen_loop ~equal ~mask ~travel keys k hashes h i =
+    t.keys k t.hashes h ~first_dead:(-1) i
+and locate_gen_loop ~equal ~mask ~travel keys k hashes h ~first_dead i =
   incr travel;
   if verbose then incr locate_travel;
   let h' = Array.unsafe_get hashes i in
   let i' = (i + 1) land mask in
   if h' <> h then
-    if h' = H.void then Error i
-    else locate_gen_loop ~equal ~mask ~travel keys k hashes h i'
+    if h' = H.void then begin
+      let i = if first_dead < 0 then i else first_dead in
+      Error (i, first_dead < 0)
+    end
+    else locate_gen_loop ~equal ~mask ~travel keys k hashes h ~first_dead i'
   else
     match Weak.get keys i with
     | Some hc when equal k hc.node -> Ok hc
-    | _ ->
+    | Some hc ->
+      if equal k hc.node then Ok hc
+      else locate_gen_loop ~equal ~mask ~travel keys k hashes h ~first_dead i'
+    | None ->
       (* When a value has been erased by the GC (case [None]), we must
          keep looking further for another value with the same hash. It
          would be incorrect to treat it as a [void] hash, for the same
          reason that François distinguishes [tomb] from [void]. *)
-      locate_gen_loop ~equal ~mask ~travel keys k hashes h i'
+      let first_dead = if first_dead < 0 then i else first_dead in
+      locate_gen_loop ~equal ~mask ~travel keys k hashes h ~first_dead i'
 
 let next_sz n = min (2*n) (Sys.max_array_length / 2)
 
@@ -179,8 +186,9 @@ let resize_gen ~equal t =
       match locate_gen ~equal t hc.node h with
       | Ok _ ->
         failwith "resize: key already in the table?";
-      | Error i ->
-        t.occupation <- t.occupation + 1;
+      | Error (i, void_or_dead) ->
+        if void_or_dead then
+          t.occupation <- t.occupation + 1;
         Weak.set new_keys i (Some hc);
         new_hashes.(i) <- h;
   done;
@@ -208,7 +216,8 @@ let compress ~equal t =
       | Some hc ->
         match locate_gen ~equal t hc.node h with
         | Ok _ -> ()
-        | Error j ->
+        | Error (j, void_or_dead) ->
+          if verbose then assert void_or_dead;
           Weak.set t.keys j (Some hc);
           Weak.set t.keys i None;
           t.hashes.(j) <- t.hashes.(i);
@@ -283,12 +292,13 @@ let hashcons_gen ~hash ~equal t k =
   | Ok hc ->
     if verbose then incr hits;
     hc
-  | Error i ->
+  | Error (i, void_or_dead) ->
     if verbose then incr misses;
     let hc = { hkey; tag = gentag (); node = k } in
     Weak.set t.keys i (Some hc);
     Array.unsafe_set t.hashes i h;
-    t.occupation <- t.occupation + 1;
+    if void_or_dead then
+      t.occupation <- t.occupation + 1;
     hc
 
 let stats t =

--- a/hashcons.mli
+++ b/hashcons.mli
@@ -87,7 +87,7 @@ module type S =
     val stats : t -> int * int * int * int * int * int
   end
 
-module Make(H : HashedType) : (S with type key = H.t)
+module Make(K : HashedType) : (S with type key = K.t)
 
 
 module Hmap : sig

--- a/test_qs.ml
+++ b/test_qs.ml
@@ -178,7 +178,7 @@ let () =
   let l = list [0;3;5;2;4;1] in
   assert (normal_list (app (quicksort, l)) = [0;1;2;3;4;5]);
   printf "subst count: %d@." !subst_count;
-  let stat = Gc.stat () in
+  let stat = Gc.quick_stat () in
   printf "top heap words: %d (%d kb)@." stat.Gc.top_heap_words
     (stat.Gc.top_heap_words / 256);
   let l,n,s,b1,b2,b3 = Term.stats ht in


### PR DESCRIPTION
This commit reimplements the weak hash tables of `ocaml-hashcons` using open-adressing hash tables with linear probing. The implementation is loosely inspired from François Pottier's `hachis` library ( https://github.com/fpottier/hachis/ ), from which the suggestion comes that open-addressing hash tables can be competitive with the array-of-buckets design commonly found in OCaml libraries.

One interesting aspect of open-addressing hash tables is that we can use a single large weak array, instead of many smaller weak arrays of buckets. (At this point I don't know whether this difference should make things faster or slower.)

(This is joint work with @iuliadmtru, we worked on this during the [Rocq'n'share 2026](https://proofs.swiss/rocq-n-share/2026/) in Lausanne.)

The 'hashcons' library comes with three benchmarks representing three very different workloads:

1. quicksort: 'test_qs.exe', which reduces a large lambda-calculus term implementing a quicksort, has a hit rate of 99.8%, that is, virtually all 'hashcons' call succeed by finding a value already in the hash set. Terms get collected very slowly.

   The new implementation struggles on this workload: on my machine it is around 1.1x slower than the previous implementation, with similar memory usage. (We had to implement specific logic to avoid a 2x slowdown on this benchmark.)

2. pigeons: 'bench_bdd.exe -pigeon 11' is more balanced, with a hit rate of 44.6%, but terms that are largely long-lived -- the number of distinct live elements grows over time so the table needs to be resized repeatedly.

   The new implementation is 1.21x faster on this benchmark, with similar memory usage.

3. indices; 'bench_bdd.exe -de-bruijn 400' has a hit rate of 1.2%: most terms in the table are new, and in fact most terms are relatively short-lived and get collected quickly.

   The new implementation uses 7x less memory and is 2.85x faster on this benchmark.

These results suggest that the new implementation could be an improvement over the previous one for certain workloads.

We wrote this with the intention of adopting the same approach in the hash-consing layer of Rocq (moving from an array-of-buckets design to an open-addressing design); but at this point we don't know to which of the three workloads Rocq is closer to. (We suspect that it is in-betwen (1) and (2), so it is really unclear what the gains would be for Rocq.)
